### PR TITLE
#63 add prehook to make travis build status branch specific

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+"""
+Referencing current branch in github readme.md[1]
+
+This pre-commit hook[2] updates the README.md file's
+Travis badge with the current branch. Gist at[4].
+
+[1] http://stackoverflow.com/questions/18673694/referencing-current-branch-in-github-readme-md
+[2] http://www.git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+[3] https://docs.travis-ci.com/user/status-images/
+[4] https://gist.github.com/dandye/dfe0870a6a1151c89ed9
+"""
+import subprocess
+
+# Hard-Coded for your repo (ToDo: get from remote?)
+GITHUB_USER="joegattnet"
+REPO="joegattnet_v3"
+
+print "Starting pre-commit hook..."
+
+BRANCH=subprocess.check_output(["git",
+                                "rev-parse",
+                                "--abbrev-ref",
+                                "HEAD"]).strip()
+
+# String with hard-coded values
+# See Embedding Status Images[3] for alternate formats (private repos, svg, etc)
+
+#  [![Build Status](https://api.travis-ci.org/
+#  intuit/foremast-brain.png?
+#  branch=staging)][travis]
+
+# Output String with Variable substitution
+travis="[![Build Status](https://api.travis-ci.org/" \
+       "{GITHUB_USER}/{REPO}.png?" \
+       "branch={BRANCH})][travis]\n".format(BRANCH=BRANCH,
+                                            GITHUB_USER=GITHUB_USER,
+                                            REPO=REPO)
+
+sentinel_str="[![Build Status]"
+
+readmelines=open("README.md").readlines()
+with open("README.md", "w") as fh:
+    for aline in readmelines:
+        if sentinel_str in aline and travis != aline:
+            print "Replacing:\n\t{aline}\nwith:\n\t{travis}".format(
+                   aline=aline,
+                   travis=travis)
+            fh.write(travis)
+        else:
+            fh.write(aline)
+
+subprocess.check_output(["git", "add", "README.md" ])
+
+print "pre-commit hook complete."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,8 +13,8 @@ Travis badge with the current branch. Gist at[4].
 import subprocess
 
 # Hard-Coded for your repo (ToDo: get from remote?)
-GITHUB_USER="joegattnet"
-REPO="joegattnet_v3"
+GITHUB_USER="intuit"
+REPO="foremast_brain"
 
 print "Starting pre-commit hook..."
 
@@ -28,12 +28,12 @@ BRANCH=subprocess.check_output(["git",
 
 #  [![Build Status](https://api.travis-ci.org/
 #  intuit/foremast-brain.png?
-#  branch=staging)][travis]
+#  branch=staging)]
 
 # Output String with Variable substitution
 travis="[![Build Status](https://api.travis-ci.org/" \
        "{GITHUB_USER}/{REPO}.png?" \
-       "branch={BRANCH})][travis]\n".format(BRANCH=BRANCH,
+       "branch={BRANCH})]\n".format(BRANCH=BRANCH,
                                             GITHUB_USER=GITHUB_USER,
                                             REPO=REPO)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foremast Brain
-[![Build Status](https://api.travis-ci.org/intuit/foremast_brain.png?branch=dev)]
+[![Build Status](https://api.travis-ci.org/intuit/foremast_brain.png?branch=dev)]((https://travis-ci.org/intuit/foremast_brain))
 [![Slack Chat](https://img.shields.io/badge/slack-live-orange.svg)](https://foremastio.slack.com/)
 
 ![](https://github.com/intuit/foremast/blob/master/docs/assets/images/logos/Foremast/foremast-logo-blue.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foremast Brain
-[![Build Status](https://api.travis-ci.org/intuit/foremast-brain.svg?branch=master)](https://www.travis-ci.org/intuit/foremast-brain)
+[![Build Status](https://travis-ci.org/intuit/foremast-brain.svg?branch=master)][travis]
 [![Slack Chat](https://img.shields.io/badge/slack-live-orange.svg)](https://foremastio.slack.com/)
 
 ![](https://github.com/intuit/foremast/blob/master/docs/assets/images/logos/Foremast/foremast-logo-blue.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foremast Brain
-[![Build Status](https://api.travis-ci.org/intuit/foremast_brain.png?branch=test)]
+[![Build Status](https://api.travis-ci.org/intuit/foremast_brain.png?branch=dev)]
 [![Slack Chat](https://img.shields.io/badge/slack-live-orange.svg)](https://foremastio.slack.com/)
 
 ![](https://github.com/intuit/foremast/blob/master/docs/assets/images/logos/Foremast/foremast-logo-blue.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foremast Brain
-[![Build Status](https://api.travis-ci.org/joegattnet/joegattnet_v3.png?branch=dev)]
+[![Build Status](https://api.travis-ci.org/intuit/foremast_brain.png?branch=test)]
 [![Slack Chat](https://img.shields.io/badge/slack-live-orange.svg)](https://foremastio.slack.com/)
 
 ![](https://github.com/intuit/foremast/blob/master/docs/assets/images/logos/Foremast/foremast-logo-blue.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foremast Brain
-[![Build Status](https://travis-ci.org/intuit/foremast-brain.svg?branch=master)][travis]
+[![Build Status](https://api.travis-ci.org/joegattnet/joegattnet_v3.png?branch=dev)][travis]
 [![Slack Chat](https://img.shields.io/badge/slack-live-orange.svg)](https://foremastio.slack.com/)
 
 ![](https://github.com/intuit/foremast/blob/master/docs/assets/images/logos/Foremast/foremast-logo-blue.png)
@@ -56,6 +56,12 @@ env:
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
+## Setup
+```
+git clone https://github.com/intuit/foremast-brain
+cp .githooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
 ## License
 
 This project is licensed under the Apache License - see the [LICENSE](LICENSE) file for details

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foremast Brain
-[![Build Status](https://api.travis-ci.org/joegattnet/joegattnet_v3.png?branch=dev)][travis]
+[![Build Status](https://api.travis-ci.org/joegattnet/joegattnet_v3.png?branch=dev)]
 [![Slack Chat](https://img.shields.io/badge/slack-live-orange.svg)](https://foremastio.slack.com/)
 
 ![](https://github.com/intuit/foremast/blob/master/docs/assets/images/logos/Foremast/foremast-logo-blue.png)


### PR DESCRIPTION
Fixes #63

the travis build status url was hardcoded to point to master branch.
this change will make it dynamic for each branch.
updated Readme to get the git pre-commit files as part of local setup